### PR TITLE
Improved error handling for /token

### DIFF
--- a/src/components/token/token-controller.js
+++ b/src/components/token/token-controller.js
@@ -74,7 +74,11 @@ export function generateAuthenticationToken(authenticationProvider, accessToken,
       getUserDetailsPromise = getStackExchangeUserDetails;
       break;
     default:
-      throw new Error('Authentication Provider Required');
+      return Promise.reject((() => {
+        const error = new Error('Invalid authentication provider');
+        error.status = 422;
+        return error;
+      })());
   }
 
   return getUserDetailsPromise(accessToken, accessAppKey)

--- a/src/components/token/token-routes.js
+++ b/src/components/token/token-routes.js
@@ -30,7 +30,7 @@ router.post('/', (req, res) => {
       if (error.message === 'Unauthorized') {
         return res.status(401).json({ error: error.message });
       }
-      return res.status(500).json({ error: error.message });
+      return res.status(error.status || 500).json({ error: error.message });
     });
 });
 

--- a/src/components/token/token-routes.js
+++ b/src/components/token/token-routes.js
@@ -7,14 +7,30 @@ router.post('/', (req, res) => {
   const authenticationProvider = req.body.authenticationProvider;
   const accessToken = req.body.accessToken;
   const accessAppKey = req.body.accessAppKey;
+  const missingParams = [];
 
-  token.generateAuthenticationToken(authenticationProvider, accessToken, accessAppKey)
+  if (!authenticationProvider) {
+    missingParams.push('authenticationProvider');
+  }
+  if (!accessToken) {
+    missingParams.push('accessToken');
+  }
+  if (!accessAppKey) {
+    missingParams.push('accessAppKey');
+  }
+
+  if (missingParams.length > 0) {
+    const errorMessage = `Missing parameters: ${missingParams.join(', ')}`;
+    return res.status(422).json({ error: errorMessage });
+  }
+
+  return token.generateAuthenticationToken(authenticationProvider, accessToken, accessAppKey)
     .then(authDetails => res.json(authDetails))
     .catch(error => {
-      if (error.name === 'ThirdPartyAuthenticationError') {
-        return res.status(422).json({ error: error.message });
+      if (error.message === 'Unauthorized') {
+        return res.status(401).json({ error: error.message });
       }
-      throw error;
+      return res.status(500).json({ error: error.message });
     });
 });
 


### PR DESCRIPTION
- Return which parameters are missing in request.
- `throw error` made the app crash, replaced with `res.json`.
- Added response status of 401 Unauthorized.
- Couldn't find `ThirdPartyAuthenticationError` anywhere in the code, so removed it (right?).